### PR TITLE
Cancel any cancelable input promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ module.exports = (promise, ms, fallback) => new Promise((resolve, reject) => {
 		const message = typeof fallback === 'string' ? fallback : `Promise timed out after ${ms} milliseconds`;
 		const err = fallback instanceof Error ? fallback : new TimeoutError(message);
 
+		if (typeof promise.cancel === 'function') {
+			promise.cancel();
+		}
+
 		reject(err);
 	}, ms);
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "ava": "*",
     "delay": "^2.0.0",
+    "p-cancelable": "^0.3.0",
     "xo": "*"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 import delay from 'delay';
+import PCancelable from 'p-cancelable';
 import m from '.';
 
 const fixture = Symbol('fixture');
@@ -21,4 +22,17 @@ test('fallback argument', async t => {
 	await t.throws(m(delay(200), 50, 'rainbow'), 'rainbow');
 	await t.throws(m(delay(200), 50, new RangeError('cake')), RangeError);
 	await t.throws(m(delay(200), 50, () => Promise.reject(fixtureErr)), fixtureErr.message);
+});
+
+test('calls `.cancel()` on promise when it exists', async t => {
+	const p = new PCancelable(onCancel => {
+		onCancel(() => {
+			t.pass();
+		});
+
+		return delay(200);
+	});
+
+	await t.throws(m(p, 50), m.TimeoutError);
+	t.true(p.canceled);
 });


### PR DESCRIPTION
If we want to add a `.cancel()` method to it, do we want to throw in there on cancel? Not sure how the implementation would look either if we don't use `p-cancelable` or `p-defer`.

Fixes #2.