### PR TITLE
Catch error thrown in fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const pFinally = require('p-finally');
+const pTry = require('p-try');
 
 class TimeoutError extends Error {
 	constructor(message) {
@@ -15,7 +16,7 @@ module.exports = (promise, ms, fallback) => new Promise((resolve, reject) => {
 
 	const timer = setTimeout(() => {
 		if (typeof fallback === 'function') {
-			resolve(fallback());
+			resolve(pTry(fallback));
 			return;
 		}
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 const pFinally = require('p-finally');
-const pTry = require('p-try');
 
 class TimeoutError extends Error {
 	constructor(message) {
@@ -16,7 +15,11 @@ module.exports = (promise, ms, fallback) => new Promise((resolve, reject) => {
 
 	const timer = setTimeout(() => {
 		if (typeof fallback === 'function') {
-			resolve(pTry(fallback));
+			try {
+				resolve(fallback());
+			} catch (err) {
+				reject(err);
+			}
 			return;
 		}
 

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "bluebird"
   ],
   "dependencies": {
-    "p-finally": "^1.0.0",
-    "p-try": "^1.0.0"
+    "p-finally": "^1.0.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "bluebird"
   ],
   "dependencies": {
-    "p-finally": "^1.0.0"
+    "p-finally": "^1.0.0",
+    "p-try": "^1.0.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/test.js
+++ b/test.js
@@ -30,6 +30,9 @@ test('fallback argument', async t => {
 	await t.throws(m(delay(200), 50, 'rainbow'), 'rainbow');
 	await t.throws(m(delay(200), 50, new RangeError('cake')), RangeError);
 	await t.throws(m(delay(200), 50, () => Promise.reject(fixtureErr)), fixtureErr.message);
+	await t.throws(m(delay(200), 50, () => {
+		throw new RangeError('cake');
+	}), RangeError);
 });
 
 test('calls `.cancel()` on promise when it exists', async t => {


### PR DESCRIPTION
This protects developers from accidentally throw an errors
inside the fallback function, they now are converted into a rejected promise.

closes #7