### PR TITLE
Fix browser compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const pTimeout = (promise, milliseconds, fallback, options) => new Promise((reso
 		...options
 	};
 
-	const timer = options.customTimers.setTimeout(() => {
+	const timer = options.customTimers.setTimeout.call(undefined, () => {
 		if (typeof fallback === 'function') {
 			try {
 				resolve(fallback());
@@ -49,7 +49,7 @@ const pTimeout = (promise, milliseconds, fallback, options) => new Promise((reso
 		} catch (error) {
 			reject(error);
 		} finally {
-			options.customTimers.clearTimeout(timer);
+			options.customTimers.clearTimeout.call(undefined, timer);
 		}
 	})();
 });


### PR DESCRIPTION
#17 broke this package for browsers.

- Chrome: "TypeError: Illegal invocation"
- Safari: "TypeError: Can only call Window.setTimeout on instances of Window"