### PR TITLE
Report rejection after timeout

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 declare class TimeoutErrorClass extends Error {
 	readonly name: 'TimeoutError';
+	readonly promise?: Promise<unknown>;
 	constructor(message?: string);
 }
 

--- a/index.js
+++ b/index.js
@@ -40,6 +40,9 @@ const pTimeout = (promise, milliseconds, fallback, options) => {
 
 			if (typeof promise.cancel === 'function') {
 				promise.cancel();
+			} else {
+				// `.catch(undefined)` needed to report `unhandledRejection`
+				timeoutError.promise = promise.catch(undefined);
 			}
 
 			reject(timeoutError);


### PR DESCRIPTION
...as `unhandledRejection` by default, but allow to handle it.

I don't know how to test this. I'm surprised no test failed on my machine.