### PR TITLE
Add types field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"index.js",
 		"index.d.ts"
 	],
+	"types": "./index.d.ts",
 	"keywords": [
 		"promise",
 		"timeout",


### PR DESCRIPTION
Noticed there are types present but not referenced so typescript doesnt pick them up yet.