### PR TITLE
Update option parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,10 +35,12 @@ const getAbortedReason = signal => {
 	return reason instanceof Error ? reason : getDOMException(reason);
 };
 
-export default function pTimeout(promise, milliseconds, fallback, options) {
+export default function pTimeout(promise, options) {
 	let timer;
 
 	const cancelablePromise = new Promise((resolve, reject) => {
+		const {milliseconds, fallback, message} = options;
+
 		if (typeof milliseconds !== 'number' || Math.sign(milliseconds) !== 1) {
 			throw new TypeError(`Expected \`milliseconds\` to be a positive number, got \`${milliseconds}\``);
 		}
@@ -65,7 +67,7 @@ export default function pTimeout(promise, milliseconds, fallback, options) {
 		}
 
 		timer = options.customTimers.setTimeout.call(undefined, () => {
-			if (typeof fallback === 'function') {
+			if (fallback) {
 				try {
 					resolve(fallback());
 				} catch (error) {
@@ -75,8 +77,8 @@ export default function pTimeout(promise, milliseconds, fallback, options) {
 				return;
 			}
 
-			const message = typeof fallback === 'string' ? fallback : `Promise timed out after ${milliseconds} milliseconds`;
-			const timeoutError = fallback instanceof Error ? fallback : new TimeoutError(message);
+			const errorMessage = typeof message === 'string' ? message : `Promise timed out after ${milliseconds} milliseconds`;
+			const timeoutError = message instanceof Error ? message : new TimeoutError(errorMessage);
 
 			if (typeof promise.cancel === 'function') {
 				promise.cancel();

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -2,45 +2,52 @@
 import {expectType, expectError} from 'tsd';
 import pTimeout, {TimeoutError} from './index.js';
 
-const delayedPromise: () => Promise<string> = async () => {
-	return new Promise(resolve => {
-		setTimeout(() => {
-			resolve('foo');
-		}, 200);
-	});
-};
-
-pTimeout(delayedPromise(), 50).then(() => 'foo');
-pTimeout(delayedPromise(), 50, async () => {
-	return pTimeout(delayedPromise(), 300);
+const delayedPromise: () => Promise<string> = async () => new Promise(resolve => {
+	setTimeout(() => {
+		resolve('foo');
+	}, 200);
 });
-pTimeout(delayedPromise(), 50).then(value => expectType<string>(value));
-pTimeout(delayedPromise(), 50, 'error').then(value =>
+
+pTimeout(delayedPromise(), {milliseconds: 50}).then(() => 'foo');
+pTimeout(delayedPromise(), {milliseconds: 50, fallback: async () => pTimeout(delayedPromise(), {milliseconds: 300})});
+pTimeout(delayedPromise(), {milliseconds: 50}).then(value => expectType<string>(value));
+pTimeout(delayedPromise(), {milliseconds: 50, message: 'error'}).then(value =>
 	expectType<string>(value)
 );
-pTimeout(delayedPromise(), 50, new Error('error')).then(value =>
+pTimeout(delayedPromise(), {milliseconds: 50, message: new Error('error')}).then(value =>
 	expectType<string>(value)
 );
-pTimeout(delayedPromise(), 50, async () => 10).then(value => {
+pTimeout(delayedPromise(), {milliseconds: 50, fallback: async () => 10}).then(value => {
 	expectType<string | number>(value);
 });
-pTimeout(delayedPromise(), 50, () => 10).then(value => {
+pTimeout(delayedPromise(), {milliseconds: 50, fallback: () => 10}).then(value => {
 	expectType<string | number>(value);
 });
 
 const customTimers = {setTimeout, clearTimeout};
-pTimeout(delayedPromise(), 50, undefined, {customTimers});
-pTimeout(delayedPromise(), 50, 'foo', {customTimers});
-pTimeout(delayedPromise(), 50, new Error('error'), {customTimers});
-pTimeout(delayedPromise(), 50, () => 10, {});
+pTimeout(delayedPromise(), {milliseconds: 50, customTimers});
+pTimeout(delayedPromise(), {milliseconds: 50, message: 'foo', customTimers});
+pTimeout(delayedPromise(), {milliseconds: 50, message: new Error('error'), customTimers});
+pTimeout(delayedPromise(), {milliseconds: 50, fallback: () => 10});
 
-expectError(pTimeout(delayedPromise(), 50, () => 10, {customTimers: {setTimeout}}));
-expectError(pTimeout(delayedPromise(), 50, () => 10, {
+expectError(pTimeout(delayedPromise(), {
+	milliseconds: 50,
+	fallback: () => 10,
+	customTimers: {
+		setTimeout
+	}
+}));
+
+expectError(pTimeout(delayedPromise(), {
+	milliseconds: 50,
+	fallback: () => 10,
 	customTimers: {
 		setTimeout: () => 42, // Invalid `setTimeout` implementation
 		clearTimeout
 	}
 }));
+
+expectError(pTimeout(delayedPromise(), {})); // `milliseconds` is required
 
 const timeoutError = new TimeoutError();
 expectType<TimeoutError>(timeoutError);

--- a/readme.md
+++ b/readme.md
@@ -16,14 +16,15 @@ import pTimeout from 'p-timeout';
 
 const delayedPromise = setTimeout(200);
 
-await pTimeout(delayedPromise, 50);
+await pTimeout(delayedPromise, {
+	milliseconds: 50,
+});
 //=> [TimeoutError: Promise timed out after 50 milliseconds]
 ```
 
 ## API
 
-### pTimeout(input, milliseconds, message?, options?)
-### pTimeout(input, milliseconds, fallback?, options?)
+### pTimeout(input, options)
 
 Returns a decorated `input` that times out after `milliseconds` time. It has a `.clear()` method that clears the timeout.
 
@@ -35,7 +36,11 @@ Type: `Promise`
 
 Promise to decorate.
 
-#### milliseconds
+#### options
+
+Type: `object`
+
+##### milliseconds
 
 Type: `number`
 
@@ -43,7 +48,7 @@ Milliseconds before timing out.
 
 Passing `Infinity` will cause it to never time out.
 
-#### message
+##### message
 
 Type: `string | Error`\
 Default: `'Promise timed out after 50 milliseconds'`
@@ -52,7 +57,7 @@ Specify a custom error message or error.
 
 If you do a custom error, it's recommended to sub-class `pTimeout.TimeoutError`.
 
-#### fallback
+##### fallback
 
 Type: `Function`
 
@@ -66,14 +71,13 @@ import pTimeout from 'p-timeout';
 
 const delayedPromise = () => setTimeout(200);
 
-await pTimeout(delayedPromise(), 50, () => {
-	return pTimeout(delayedPromise(), 300);
+await pTimeout(delayedPromise(), {
+	milliseconds: 50,
+	fallback: () => {
+		return pTimeout(delayedPromise(), 300);
+	},
 });
 ```
-
-#### options
-
-Type: `object`
 
 ##### customTimers
 
@@ -95,7 +99,8 @@ const originalClearTimeout = clearTimeout;
 sinon.useFakeTimers();
 
 // Use `pTimeout` without being affected by `sinon.useFakeTimers()`:
-await pTimeout(doSomething(), 2000, undefined, {
+await pTimeout(doSomething(), {
+	milliseconds: 2000,
 	customTimers: {
 		setTimeout: originalSetTimeout,
 		clearTimeout: originalClearTimeout
@@ -123,7 +128,8 @@ setTimeout(() => {
 	abortController.abort();
 }, 100);
 
-await pTimeout(delayedPromise, 2000, undefined, {
+await pTimeout(delayedPromise, {
+	milliseconds: 2000,
 	signal: abortController.signal
 });
 ```


### PR DESCRIPTION
## Summary

* `milliseconds` is moved into `options`
* `message` is separated with `fallback`
* `message` is moved into `options`
* `fallback` is moved into `options`

## Reference

https://github.com/sindresorhus/p-wait-for/pull/24