### PR TITLE
Allow timing out without erroring

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,9 +43,21 @@ export type Options<ReturnType> = {
 	fallback?: () => ReturnType | Promise<ReturnType>;
 
 	/**
-	Specify a custom error message or error.
+	Specify a custom error message or error to throw when it times out:
 
-	If you do a custom error, it's recommended to sub-class `TimeoutError`.
+	- `message: 'too slow'` will throw `TimeoutError('too slow')`
+	- `message: new MyCustomError('it’s over 9000')` will throw the same error instance
+	- `message: false` will make the promise resolve with `undefined` instead of rejecting
+
+	If you do a custom error, it's recommended to sub-class `TimeoutError`:
+
+	```js
+	import {TimeoutError} from 'p-timeout';
+
+	class MyCustomError extends TimeoutError {
+		name = "MyCustomError";
+	}
+	```
 	*/
 	message?: string | Error | false;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ export type Options<ReturnType> = {
 
 	If you do a custom error, it's recommended to sub-class `pTimeout.TimeoutError`.
 	*/
-	message?: string | Error;
+	message?: string | Error | false;
 
 	/**
 	Custom implementations for the `setTimeout` and `clearTimeout` functions.

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ export type Options<ReturnType> = {
 
 	If you do a custom error, it's recommended to sub-class `pTimeout.TimeoutError`.
 	*/
-	message?: string | Error | false;
+	error?: string | Error | false;
 
 	/**
 	Custom implementations for the `setTimeout` and `clearTimeout` functions.

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ export type Options<ReturnType> = {
 
 	If you do a custom error, it's recommended to sub-class `TimeoutError`.
 	*/
-	error?: string | Error | false;
+	message?: string | Error | false;
 
 	/**
 	Custom implementations for the `setTimeout` and `clearTimeout` functions.

--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,7 @@ export type Options<ReturnType> = {
 
 	If you do a custom error, it's recommended to sub-class `TimeoutError`:
 
-	```js
+	```
 	import {TimeoutError} from 'p-timeout';
 
 	class MyCustomError extends TimeoutError {

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,7 +45,7 @@ export type Options<ReturnType> = {
 	/**
 	Specify a custom error message or error.
 
-	If you do a custom error, it's recommended to sub-class `pTimeout.TimeoutError`.
+	If you do a custom error, it's recommended to sub-class `TimeoutError`.
 	*/
 	error?: string | Error | false;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -143,5 +143,9 @@ await pTimeout(delayedPromise(), {
 */
 export default function pTimeout<ValueType, ReturnType = ValueType>(
 	input: PromiseLike<ValueType>,
+	options: Options<ReturnType> & {message: false}
+): ClearablePromise<ValueType | ReturnType | undefined>;
+export default function pTimeout<ValueType, ReturnType = ValueType>(
+	input: PromiseLike<ValueType>,
 	options: Options<ReturnType>
 ): ClearablePromise<ValueType | ReturnType>;

--- a/index.js
+++ b/index.js
@@ -83,12 +83,12 @@ export default function pTimeout(promise, options) {
 
 			if (message === false) {
 				resolve();
+			} else if (message instanceof Error) {
+				reject(message);
+			} else {
+				const errorMessage = message ?? `Promise timed out after ${milliseconds} milliseconds`;
+				reject(new TimeoutError(errorMessage));
 			}
-
-			const errorMessage = typeof message === 'string' ? message : `Promise timed out after ${milliseconds} milliseconds`;
-			const timeoutError = message instanceof Error ? message : new TimeoutError(errorMessage);
-
-			reject(timeoutError);
 		}, milliseconds);
 
 		(async () => {

--- a/index.js
+++ b/index.js
@@ -77,12 +77,16 @@ export default function pTimeout(promise, options) {
 				return;
 			}
 
-			const errorMessage = typeof message === 'string' ? message : `Promise timed out after ${milliseconds} milliseconds`;
-			const timeoutError = message instanceof Error ? message : new TimeoutError(errorMessage);
-
 			if (typeof promise.cancel === 'function') {
 				promise.cancel();
 			}
+			
+			if (message === false) {
+				resolve();
+			}
+
+			const errorMessage = typeof message === 'string' ? message : `Promise timed out after ${milliseconds} milliseconds`;
+			const timeoutError = message instanceof Error ? message : new TimeoutError(errorMessage);
 
 			reject(timeoutError);
 		}, milliseconds);

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ export default function pTimeout(promise, options) {
 	const {
 		milliseconds,
 		fallback,
-		error,
+		message,
 		customTimers = {setTimeout, clearTimeout},
 	} = options;
 
@@ -81,12 +81,12 @@ export default function pTimeout(promise, options) {
 				promise.cancel();
 			}
 
-			if (error === false) {
+			if (message === false) {
 				resolve();
-			} else if (error instanceof Error) {
-				reject(error);
+			} else if (message instanceof Error) {
+				reject(message);
 			} else {
-				const errorMessage = error ?? `Promise timed out after ${milliseconds} milliseconds`;
+				const errorMessage = message ?? `Promise timed out after ${milliseconds} milliseconds`;
 				reject(new TimeoutError(errorMessage));
 			}
 		}, milliseconds);

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ export default function pTimeout(promise, options) {
 			if (typeof promise.cancel === 'function') {
 				promise.cancel();
 			}
-			
+
 			if (message === false) {
 				resolve();
 			}

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ export default function pTimeout(promise, options) {
 	const {
 		milliseconds,
 		fallback,
-		message,
+		error,
 		customTimers = {setTimeout, clearTimeout},
 	} = options;
 
@@ -81,12 +81,12 @@ export default function pTimeout(promise, options) {
 				promise.cancel();
 			}
 
-			if (message === false) {
+			if (error === false) {
 				resolve();
-			} else if (message instanceof Error) {
-				reject(message);
+			} else if (error instanceof Error) {
+				reject(error);
 			} else {
-				const errorMessage = message ?? `Promise timed out after ${milliseconds} milliseconds`;
+				const errorMessage = error ?? `Promise timed out after ${milliseconds} milliseconds`;
 				reject(new TimeoutError(errorMessage));
 			}
 		}, milliseconds);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -13,13 +13,13 @@ pTimeout(delayedPromise(), {milliseconds: 50, fallback: async () => pTimeout(del
 pTimeout(delayedPromise(), {milliseconds: 50}).then(value => {
 	expectType<string>(value);
 });
-pTimeout(delayedPromise(), {milliseconds: 50, error: 'error'}).then(value => {
+pTimeout(delayedPromise(), {milliseconds: 50, message: 'error'}).then(value => {
 	expectType<string>(value);
 });
-pTimeout(delayedPromise(), {milliseconds: 50, error: false}).then(value => {
+pTimeout(delayedPromise(), {milliseconds: 50, message: false}).then(value => {
 	expectType<string>(value);
 });
-pTimeout(delayedPromise(), {milliseconds: 50, error: new Error('error')}).then(value => {
+pTimeout(delayedPromise(), {milliseconds: 50, message: new Error('error')}).then(value => {
 	expectType<string>(value);
 });
 pTimeout(delayedPromise(), {milliseconds: 50, fallback: async () => 10}).then(value => {
@@ -31,8 +31,8 @@ pTimeout(delayedPromise(), {milliseconds: 50, fallback: () => 10}).then(value =>
 
 const customTimers = {setTimeout, clearTimeout};
 pTimeout(delayedPromise(), {milliseconds: 50, customTimers});
-pTimeout(delayedPromise(), {milliseconds: 50, error: 'foo', customTimers});
-pTimeout(delayedPromise(), {milliseconds: 50, error: new Error('error'), customTimers});
+pTimeout(delayedPromise(), {milliseconds: 50, message: 'foo', customTimers});
+pTimeout(delayedPromise(), {milliseconds: 50, message: new Error('error'), customTimers});
 pTimeout(delayedPromise(), {milliseconds: 50, fallback: () => 10});
 
 expectError(pTimeout(delayedPromise(), {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -16,6 +16,9 @@ pTimeout(delayedPromise(), {milliseconds: 50}).then(value => {
 pTimeout(delayedPromise(), {milliseconds: 50, message: 'error'}).then(value => {
 	expectType<string>(value);
 });
+pTimeout(delayedPromise(), {milliseconds: 50, message: false}).then(value => {
+	expectType<string>(value);
+});
 pTimeout(delayedPromise(), {milliseconds: 50, message: new Error('error')}).then(value => {
 	expectType<string>(value);
 });

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -17,7 +17,7 @@ pTimeout(delayedPromise(), {milliseconds: 50, message: 'error'}).then(value => {
 	expectType<string>(value);
 });
 pTimeout(delayedPromise(), {milliseconds: 50, message: false}).then(value => {
-	expectType<string>(value);
+	expectType<string | undefined>(value);
 });
 pTimeout(delayedPromise(), {milliseconds: 50, message: new Error('error')}).then(value => {
 	expectType<string>(value);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -13,13 +13,13 @@ pTimeout(delayedPromise(), {milliseconds: 50, fallback: async () => pTimeout(del
 pTimeout(delayedPromise(), {milliseconds: 50}).then(value => {
 	expectType<string>(value);
 });
-pTimeout(delayedPromise(), {milliseconds: 50, message: 'error'}).then(value => {
+pTimeout(delayedPromise(), {milliseconds: 50, error: 'error'}).then(value => {
 	expectType<string>(value);
 });
-pTimeout(delayedPromise(), {milliseconds: 50, message: false}).then(value => {
+pTimeout(delayedPromise(), {milliseconds: 50, error: false}).then(value => {
 	expectType<string>(value);
 });
-pTimeout(delayedPromise(), {milliseconds: 50, message: new Error('error')}).then(value => {
+pTimeout(delayedPromise(), {milliseconds: 50, error: new Error('error')}).then(value => {
 	expectType<string>(value);
 });
 pTimeout(delayedPromise(), {milliseconds: 50, fallback: async () => 10}).then(value => {
@@ -31,8 +31,8 @@ pTimeout(delayedPromise(), {milliseconds: 50, fallback: () => 10}).then(value =>
 
 const customTimers = {setTimeout, clearTimeout};
 pTimeout(delayedPromise(), {milliseconds: 50, customTimers});
-pTimeout(delayedPromise(), {milliseconds: 50, message: 'foo', customTimers});
-pTimeout(delayedPromise(), {milliseconds: 50, message: new Error('error'), customTimers});
+pTimeout(delayedPromise(), {milliseconds: 50, error: 'foo', customTimers});
+pTimeout(delayedPromise(), {milliseconds: 50, error: new Error('error'), customTimers});
 pTimeout(delayedPromise(), {milliseconds: 50, fallback: () => 10});
 
 expectError(pTimeout(delayedPromise(), {

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ Milliseconds before timing out.
 
 Passing `Infinity` will cause it to never time out.
 
-##### message
+##### error
 
 Type: `string | Error | false`\
 Default: `'Promise timed out after 50 milliseconds'`

--- a/readme.md
+++ b/readme.md
@@ -48,16 +48,16 @@ Milliseconds before timing out.
 
 Passing `Infinity` will cause it to never time out.
 
-##### error
+##### message
 
 Type: `string | Error | false`\
 Default: `'Promise timed out after 50 milliseconds'`
 
 Specify a custom error message or error to throw when it times out:
 
-- `error: 'too slow'` will throw `TimeoutError('too slow')`
-- `error: new MyCustomError('it’s over 9000')` will throw the same error instance
-- `error: false` will make the promise resolve with `undefined` instead of rejecting
+- `message: 'too slow'` will throw `TimeoutError('too slow')`
+- `message: new MyCustomError('it’s over 9000')` will throw the same error instance
+- `message: false` will make the promise resolve with `undefined` instead of rejecting
 
 If you do a custom error, it's recommended to sub-class `TimeoutError`:
 

--- a/readme.md
+++ b/readme.md
@@ -53,9 +53,21 @@ Passing `Infinity` will cause it to never time out.
 Type: `string | Error | false`\
 Default: `'Promise timed out after 50 milliseconds'`
 
-Specify a custom error message or error. If you supply `false`, the promise will resolve successfully instead of rejecting.
+Specify a custom error message or error to throw when it times out:
 
-If you do a custom error, it's recommended to sub-class `pTimeout.TimeoutError`.
+- `error: 'too slow'` will throw `TimeoutError('too slow')`
+- `error: new MyCustomError('it’s over 9000')` will throw the same error instance
+- `error: false` will make the promise resolve with `undefined` instead of rejecting
+
+If you do a custom error, it's recommended to sub-class `TimeoutError`:
+
+```js
+import {TimeoutError} from 'p-timeout';
+
+class MyCustomError extends TimeoutError {
+	name = "MyCustomError";
+}
+```
 
 ##### fallback
 

--- a/readme.md
+++ b/readme.md
@@ -50,10 +50,10 @@ Passing `Infinity` will cause it to never time out.
 
 ##### message
 
-Type: `string | Error`\
+Type: `string | Error | false`\
 Default: `'Promise timed out after 50 milliseconds'`
 
-Specify a custom error message or error.
+Specify a custom error message or error. If you supply `false`, the promise will resolve successfully instead of rejecting.
 
 If you do a custom error, it's recommended to sub-class `pTimeout.TimeoutError`.
 

--- a/test.js
+++ b/test.js
@@ -35,6 +35,13 @@ test('rejects after timeout', async t => {
 	await t.throwsAsync(pTimeout(delay(200), {milliseconds: 50}), {instanceOf: TimeoutError});
 });
 
+test('resolves after timeout with message:false', async t => {
+	t.is(
+		await pTimeout(delay(200), {milliseconds: 50, message: false}),
+		undefined,
+	);
+});
+
 test('rejects before timeout if specified promise rejects', async t => {
 	await t.throwsAsync(pTimeout(delay(50).then(() => {
 		throw fixtureError;

--- a/test.js
+++ b/test.js
@@ -35,9 +35,9 @@ test('rejects after timeout', async t => {
 	await t.throwsAsync(pTimeout(delay(200), {milliseconds: 50}), {instanceOf: TimeoutError});
 });
 
-test('resolves after timeout with message:false', async t => {
+test('resolves after timeout with error:false', async t => {
 	t.is(
-		await pTimeout(delay(200), {milliseconds: 50, message: false}),
+		await pTimeout(delay(200), {milliseconds: 50, error: false}),
 		undefined,
 	);
 });
@@ -49,8 +49,8 @@ test('rejects before timeout if specified promise rejects', async t => {
 });
 
 test('fallback argument', async t => {
-	await t.throwsAsync(pTimeout(delay(200), {milliseconds: 50, message: 'rainbow'}), {message: 'rainbow'});
-	await t.throwsAsync(pTimeout(delay(200), {milliseconds: 50, message: new RangeError('cake')}), {instanceOf: RangeError});
+	await t.throwsAsync(pTimeout(delay(200), {milliseconds: 50, error: 'rainbow'}), {message: 'rainbow'});
+	await t.throwsAsync(pTimeout(delay(200), {milliseconds: 50, error: new RangeError('cake')}), {instanceOf: RangeError});
 	await t.throwsAsync(pTimeout(delay(200), {milliseconds: 50, fallback: () => Promise.reject(fixtureError)}), {message: fixtureError.message});
 	await t.throwsAsync(pTimeout(delay(200), {milliseconds: 50, fallback() {
 		throw new RangeError('cake');

--- a/test.js
+++ b/test.js
@@ -35,9 +35,9 @@ test('rejects after timeout', async t => {
 	await t.throwsAsync(pTimeout(delay(200), {milliseconds: 50}), {instanceOf: TimeoutError});
 });
 
-test('resolves after timeout with error:false', async t => {
+test('resolves after timeout with message:false', async t => {
 	t.is(
-		await pTimeout(delay(200), {milliseconds: 50, error: false}),
+		await pTimeout(delay(200), {milliseconds: 50, message: false}),
 		undefined,
 	);
 });
@@ -49,8 +49,8 @@ test('rejects before timeout if specified promise rejects', async t => {
 });
 
 test('fallback argument', async t => {
-	await t.throwsAsync(pTimeout(delay(200), {milliseconds: 50, error: 'rainbow'}), {message: 'rainbow'});
-	await t.throwsAsync(pTimeout(delay(200), {milliseconds: 50, error: new RangeError('cake')}), {instanceOf: RangeError});
+	await t.throwsAsync(pTimeout(delay(200), {milliseconds: 50, message: 'rainbow'}), {message: 'rainbow'});
+	await t.throwsAsync(pTimeout(delay(200), {milliseconds: 50, message: new RangeError('cake')}), {instanceOf: RangeError});
 	await t.throwsAsync(pTimeout(delay(200), {milliseconds: 50, fallback: () => Promise.reject(fixtureError)}), {message: fixtureError.message});
 	await t.throwsAsync(pTimeout(delay(200), {milliseconds: 50, fallback() {
 		throw new RangeError('cake');


### PR DESCRIPTION
Like we do in `element-ready`, sometimes timeouts are not errors:

https://github.com/sindresorhus/element-ready#timeout

Thoughts on this proposal before I continue?