### PR TITLE
fix: preserve error stack trace in timer

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ export default function pTimeout(promise, options) {
 				reject(getAbortedReason(signal));
 			});
 		}
-
+		const timeoutError new TimeoutError();
 		timer = customTimers.setTimeout.call(undefined, () => {
 			if (fallback) {
 				try {
@@ -87,7 +87,8 @@ export default function pTimeout(promise, options) {
 				reject(message);
 			} else {
 				const errorMessage = message ?? `Promise timed out after ${milliseconds} milliseconds`;
-				reject(new TimeoutError(errorMessage));
+				timeoutError.message = errorMessage;
+				reject(timeoutError);
 			}
 		}, milliseconds);
 


### PR DESCRIPTION
when error occurred that made in callback function in timer, 
error stack is missing. 
So to prevent from missing error stack, I declared error from outer of timer callback. 