### PR TITLE
fix: preserve error stack trace in timer

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ export default function pTimeout(promise, options) {
 				reject(getAbortedReason(signal));
 			});
 		}
+
 		const timeoutError = new TimeoutError();
 		timer = customTimers.setTimeout.call(undefined, () => {
 			if (fallback) {

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ export default function pTimeout(promise, options) {
 				reject(getAbortedReason(signal));
 			});
 		}
-
+		const timeoutError new TimeoutError();
 		timer = customTimers.setTimeout.call(undefined, () => {
 			if (fallback) {
 				try {
@@ -87,7 +87,8 @@ export default function pTimeout(promise, options) {
 				reject(message);
 			} else {
 				const errorMessage = message ?? `Promise timed out after ${milliseconds} milliseconds`;
-				reject(new TimeoutError(errorMessage));
+				timeoutError.message = errorMessage;
+				reject(timeoutError);
 			}
 		}, milliseconds);
 

--- a/index.js
+++ b/index.js
@@ -66,7 +66,9 @@ export default function pTimeout(promise, options) {
 			});
 		}
 
+		// We create the error outside of `setTimeout` to preserve the stack trace.
 		const timeoutError = new TimeoutError();
+
 		timer = customTimers.setTimeout.call(undefined, () => {
 			if (fallback) {
 				try {
@@ -87,8 +89,7 @@ export default function pTimeout(promise, options) {
 			} else if (message instanceof Error) {
 				reject(message);
 			} else {
-				const errorMessage = message ?? `Promise timed out after ${milliseconds} milliseconds`;
-				timeoutError.message = errorMessage;
+				timeoutError.message = message ?? `Promise timed out after ${milliseconds} milliseconds`;
 				reject(timeoutError);
 			}
 		}, milliseconds);

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ export default function pTimeout(promise, options) {
 				reject(getAbortedReason(signal));
 			});
 		}
-		const timeoutError new TimeoutError();
+		const timeoutError = new TimeoutError();
 		timer = customTimers.setTimeout.call(undefined, () => {
 			if (fallback) {
 				try {


### PR DESCRIPTION
when error occurred that made in callback function in timer,
error stack is missing.
So to prevent from missing error stack, I declared error from outer of timer callback.