### PR TITLE
Clear existing timeouts when an abort signal aborts

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ export default function pTimeout(promise, options) {
 
 	let timer;
 
-	const cancelablePromise = new Promise((resolve, reject) => {
+	const wrappedPromise = new Promise((resolve, reject) => {
 		if (typeof milliseconds !== 'number' || Math.sign(milliseconds) !== 1) {
 			throw new TypeError(`Expected \`milliseconds\` to be a positive number, got \`${milliseconds}\``);
 		}
@@ -99,10 +99,12 @@ export default function pTimeout(promise, options) {
 				resolve(await promise);
 			} catch (error) {
 				reject(error);
-			} finally {
-				customTimers.clearTimeout.call(undefined, timer);
 			}
 		})();
+	});
+
+	const cancelablePromise = wrappedPromise.finally(() => {
+		cancelablePromise.clear();
 	});
 
 	cancelablePromise.clear = () => {


### PR DESCRIPTION
### Summary

Currently, running the following code would show the error being logged, but the process would only exist after 5 seconds (the value being passed as `milliseconds`):

```typescript
import pTimeout from "p-timeout";

const promise = new Promise(() => {});
const abortController = new AbortController();

const p = pTimeout(promise, {
	milliseconds: 5000,
	signal: abortController.signal,
});

p.then(() => console.log("done")).catch((e) => console.log("error", e));

setTimeout(() => {
	abortController.abort();
}, 1000);
```

This happens because the `setTimeout` call ([see here](https://github.com/sindresorhus/p-timeout/blob/b91e04530da6858cba77c354ea9c8659c5140e59/index.js#L72)) isn't cleared when a signal has been passed and then aborted. This ongoing timeout can cause Node to hang until it's finished (if it's the only thing holding it from closing).

This PR fixes this by cleaning up the timers not only after the promise has finished, but after `p-timeout`'s own promise finishes, which includes possibly rejecting because of an abort signal.
