### PR TITLE
Fix infinite milliseconds

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,18 +99,16 @@ export default function pTimeout(promise, options) {
 				resolve(await promise);
 			} catch (error) {
 				reject(error);
+			} finally {
+				customTimers.clearTimeout.call(undefined, timer);
 			}
 		})();
 	});
 
-	const returnedPromise = cancelablePromise.finally(() => {
-		returnedPromise.clear();
-	});
-
-	returnedPromise.clear = () => {
+	cancelablePromise.clear = () => {
 		customTimers.clearTimeout.call(undefined, timer);
 		timer = undefined;
 	};
 
-	return returnedPromise;
+	return cancelablePromise;
 }

--- a/index.js
+++ b/index.js
@@ -50,11 +50,6 @@ export default function pTimeout(promise, options) {
 			throw new TypeError(`Expected \`milliseconds\` to be a positive number, got \`${milliseconds}\``);
 		}
 
-		if (milliseconds === Number.POSITIVE_INFINITY) {
-			resolve(promise);
-			return;
-		}
-
 		if (options.signal) {
 			const {signal} = options;
 			if (signal.aborted) {
@@ -64,6 +59,11 @@ export default function pTimeout(promise, options) {
 			signal.addEventListener('abort', () => {
 				reject(getAbortedReason(signal));
 			});
+		}
+
+		if (milliseconds === Number.POSITIVE_INFINITY) {
+			promise.then(resolve, reject);
+			return;
 		}
 
 		// We create the error outside of `setTimeout` to preserve the stack trace.
@@ -99,16 +99,18 @@ export default function pTimeout(promise, options) {
 				resolve(await promise);
 			} catch (error) {
 				reject(error);
-			} finally {
-				customTimers.clearTimeout.call(undefined, timer);
 			}
 		})();
 	});
 
-	cancelablePromise.clear = () => {
+	const returnedPromise = cancelablePromise.finally(() => {
+		returnedPromise.clear();
+	});
+
+	returnedPromise.clear = () => {
 		customTimers.clearTimeout.call(undefined, timer);
 		timer = undefined;
 	};
 
-	return cancelablePromise;
+	return returnedPromise;
 }

--- a/test.js
+++ b/test.js
@@ -130,4 +130,17 @@ if (globalThis.AbortController !== undefined) {
 			name: 'AbortError',
 		});
 	});
+
+	test('aborts even if milliseconds are set to infinity', async t => {
+		const abortController = new AbortController();
+
+		abortController.abort();
+
+		await t.throwsAsync(pTimeout(delay(3000), {
+			milliseconds: Number.POSITIVE_INFINITY,
+			signal: abortController.signal,
+		}), {
+			name: 'AbortError',
+		});
+	});
 }


### PR DESCRIPTION
### Summary

This PR fixes an issue where passing an abort signal is completely ignored if `milliseconds` has been passed as  `Number.POSITIVE_INFINITY`.

This is especially relevant when using [`p-wait-for`](https://github.com/sindresorhus/p-wait-for), which passes this by default.