### PR TITLE
Mention AbortSignal in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -187,4 +187,4 @@ async function buildWall(signal) {
 await buildWall(AbortSignal.timeout(60_000))
 ```
 
-You can also combine multiple signals, like when you have a timeout *and* an `AbortController` triggered with a “Cancel” button click. You can use the upcoming [AbortSignal.any()](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/any_static) helper or [`abort-utils`](https://github.com/fregante/abort-utils/blob/main/source/merge-signals.md).
+You can also combine multiple signals, like when you have a timeout *and* an `AbortController` triggered with a “Cancel” button click. You can use the upcoming [`AbortSignal.any()`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/any_static) helper or [`abort-utils`](https://github.com/fregante/abort-utils/blob/main/source/merge-signals.md).

--- a/readme.md
+++ b/readme.md
@@ -187,4 +187,4 @@ async function buildWall(signal) {
 await buildWall(AbortSignal.timeout(60_000))
 ```
 
-You can also combine multiple signals, like when you have a timeout *and* an `AbortController` triggered with a “Cancel” button click. You can use the upcoming [AbortSignal.any()](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/any_static) helper or [`abort-utils`](](https://github.com/fregante/abort-utils/blob/main/source/merge-signals.md))
+You can also combine multiple signals, like when you have a timeout *and* an `AbortController` triggered with a “Cancel” button click. You can use the upcoming [AbortSignal.any()](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/any_static) helper or [`abort-utils`](https://github.com/fregante/abort-utils/blob/main/source/merge-signals.md).

--- a/readme.md
+++ b/readme.md
@@ -187,4 +187,4 @@ async function buildWall(signal) {
 await buildWall(AbortSignal.timeout(60_000))
 ```
 
-You can also [combine multiple signals](https://github.com/fregante/abort-utils/blob/main/source/merge-signals.md), like when you have a timeout *and* an `AbortController` triggered with a “Cancel” button click.
+You can also combine multiple signals, like when you have a timeout *and* an `AbortController` triggered with a “Cancel” button click. You can use the upcoming [AbortSignal.any()](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/any_static) helper or [`abort-utils`](](https://github.com/fregante/abort-utils/blob/main/source/merge-signals.md))

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 > Timeout a promise after a specified amount of time
 
 > [!NOTE]
-> You might want to use `AbortSignal.timeout()` instead. [More info below](#abortsignal)
+> You may want to use `AbortSignal.timeout()` instead. [Learn more.](#abortsignal)
 
 ## Install
 
@@ -164,7 +164,7 @@ Exposed for instance checking and sub-classing.
 
 > Modern alternative to `p-timeout`
 
-Asynchronous functions like `fetch` can accept an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal), which can be conveniently created with [AbortSignal.timeout()](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static).
+Asynchronous functions like `fetch` can accept an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal), which can be conveniently created with [`AbortSignal.timeout()`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static).
 
 The advantage over `p-timeout` is that the promise-generating function (like `fetch`) is actually notified that the user is no longer expecting an answer, so it can interrupt its work and free resources.
 
@@ -177,7 +177,7 @@ const response = await fetch('./my-api', {signal: AbortSignal.timeout(5000)});
 async function buildWall(signal) {
 	for (const brick of bricks) {
 		signal.throwIfAborted();
-		// Or: if (signal.aborted) return;
+		// Or: if (signal.aborted) { return; }
 
 		await layBrick();
 	}
@@ -187,4 +187,4 @@ async function buildWall(signal) {
 await buildWall(AbortSignal.timeout(60_000))
 ```
 
-You can also [combine multiple signals](https://github.com/fregante/abort-utils/blob/main/source/merge-signals.md), like when you have a timeout _and_ an `AbortController` triggered with a Cancel button click.
+You can also [combine multiple signals](https://github.com/fregante/abort-utils/blob/main/source/merge-signals.md), like when you have a timeout *and* an `AbortController` triggered with a “Cancel” button click.

--- a/readme.md
+++ b/readme.md
@@ -164,7 +164,9 @@ Exposed for instance checking and sub-classing.
 
 > Modern alternative to `p-timeout`
 
-Asynchronous functions like `fetch` can accept an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal), which can conveniently be created with [AbortSignal.timeout()](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static). The advantage over `p-timeout` is that the promise-generating function (like `fetch`) is actually notified that the user is no longer expecting an answer, so it can interrupt its work and free resources.
+Asynchronous functions like `fetch` can accept an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal), which can be conveniently created with [AbortSignal.timeout()](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static).
+
+The advantage over `p-timeout` is that the promise-generating function (like `fetch`) is actually notified that the user is no longer expecting an answer, so it can interrupt its work and free resources.
 
 ```js
 // Call API, timeout after 5 seconds
@@ -184,3 +186,5 @@ async function buildWall(signal) {
 // Stop long work after 60 seconds
 await buildWall(AbortSignal.timeout(60_000))
 ```
+
+You can also [combine multiple signals](https://github.com/fregante/abort-utils/blob/main/source/merge-signals.md), like when you have a timeout _and_ an `AbortController` triggered with a Cancel button click.

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,9 @@
 
 > Timeout a promise after a specified amount of time
 
+> [!NOTE]
+> You might want to use `AbortSignal.timeout()` instead. [More info below](#abortsignal)
+
 ## Install
 
 ```sh
@@ -156,3 +159,28 @@ Exposed for instance checking and sub-classing.
 - [p-min-delay](https://github.com/sindresorhus/p-min-delay) - Delay a promise a minimum amount of time
 - [p-retry](https://github.com/sindresorhus/p-retry) - Retry a promise-returning function
 - [More…](https://github.com/sindresorhus/promise-fun)
+
+## AbortSignal
+
+> Modern alternative to `p-timeout`
+
+Asynchronous functions like `fetch` can accept an [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal), which can conveniently be created with [AbortSignal.timeout()](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static). The advantage over `p-timeout` is that the promise-generating function (like `fetch`) is actually notified that the user is no longer expecting an answer, so it can interrupt its work and free resources.
+
+```js
+// Call API, timeout after 5 seconds
+const response = await fetch('./my-api', {signal: AbortSignal.timeout(5000)});
+```
+
+```js
+async function buildWall(signal) {
+	for (const brick of bricks) {
+		signal.throwIfAborted();
+		// Or: if (signal.aborted) return;
+
+		await layBrick();
+	}
+}
+
+// Stop long work after 60 seconds
+await buildWall(AbortSignal.timeout(60_000))
+```


### PR DESCRIPTION
Follow #31 


Jest users also need a polyfill for now (https://github.com/whatwg/dom/issues/951#issuecomment-922833719) because it uses an old jsdom version, but I guess that'll soon be fixed (https://github.com/jestjs/jest/pull/13825)